### PR TITLE
feat: add PN532 reader support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,5 @@ serde_json = "1"
 app_dirs2 = "2.5.5"
 chrono = { version = "0.4.41", features = ["serde"] }
 chrono-tz = "0.10.4"
+libc = "0.2"
+once_cell = "1.19"

--- a/src-tauri/src/reader/mod.rs
+++ b/src-tauri/src/reader/mod.rs
@@ -1,0 +1,5 @@
+pub mod pn532;
+pub mod rdm6300;
+mod reader;
+
+pub use reader::{Reader, ReaderError, ReaderType};

--- a/src-tauri/src/reader/pn532.rs
+++ b/src-tauri/src/reader/pn532.rs
@@ -1,19 +1,262 @@
-use reader::{Reader, ReaderType};
+use libc::c_ulong;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use std::{thread, vec::Vec};
 
-pub struct PN532 {}
+use super::{Reader, ReaderError, ReaderType};
 
-impl Reader for PN532 {
-    fn init(&mut self) -> Result<(), Box<dyn Error>> {
-        // Initialization logic for PN532
+const PN532_I2C_ADDRESS: u16 = 0x24;
+const ACK_FRAME: [u8; 6] = [0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00];
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+const I2C_SLAVE_IOCTL: c_ulong = 0x0703;
+
+#[derive(Debug)]
+pub struct Pn532Reader {
+    device: Mutex<std::fs::File>,
+    is_initialized: bool,
+}
+
+impl Pn532Reader {
+    pub fn new(path: impl Into<String>) -> Result<Self, ReaderError> {
+        let path_string: String = path.into();
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path_string)
+            .map_err(|e| ReaderError::Device(e.to_string()))?;
+
+        configure_slave_address(file.as_raw_fd(), PN532_I2C_ADDRESS)?;
+
+        Ok(Self {
+            device: Mutex::new(file),
+            is_initialized: false,
+        })
+    }
+
+    pub fn with_default_path() -> Result<Self, ReaderError> {
+        let default_path = std::env::var("PN532_I2C_PATH").unwrap_or_else(|_| String::from("/dev/i2c-1"));
+        Self::new(default_path)
+    }
+
+    fn wakeup(&self) -> Result<(), ReaderError> {
+        let mut guard = self
+            .device
+            .lock()
+            .map_err(|_| ReaderError::Device("Failed to lock PN532 device".into()))?;
+        let wake_sequence = [0x00u8; 1];
+        guard
+            .write(&wake_sequence)
+            .map_err(|e| ReaderError::Device(e.to_string()))?;
+        thread::sleep(Duration::from_millis(20));
         Ok(())
     }
 
-    fn read_uid(&mut self, timeout: i32) -> Result<Vec<u8>, Box<dyn Error>> {
-        // Logic to read UID from PN532
-        Ok(vec![0x00, 0x01, 0x02, 0x03]) // Example UID
+    fn send_command(&self, command: u8, data: &[u8]) -> Result<(), ReaderError> {
+        let mut guard = self
+            .device
+            .lock()
+            .map_err(|_| ReaderError::Device("Failed to lock PN532 device".into()))?;
+
+        let len = (1 + data.len()) as u8; // command + payload
+        let lcs = (!len).wrapping_add(1);
+        let mut frame: Vec<u8> = Vec::with_capacity(8 + data.len());
+        frame.push(0x00); // Host to PN532 prefix for I2C
+        frame.push(0x00);
+        frame.push(0x00);
+        frame.push(0xFF);
+        frame.push(len);
+        frame.push(lcs);
+        frame.push(0xD4); // TFI host to PN532
+        frame.push(command);
+        frame.extend_from_slice(data);
+
+        let mut checksum: u8 = 0xD4;
+        checksum = checksum.wrapping_add(command);
+        for byte in data {
+            checksum = checksum.wrapping_add(*byte);
+        }
+        let dcs = (!checksum).wrapping_add(1);
+        frame.push(dcs);
+        frame.push(0x00); // Postamble
+
+        guard
+            .write(&frame)
+            .map_err(|e| ReaderError::Device(e.to_string()))?;
+        Ok(())
+    }
+
+    fn read_ack(&self, timeout: Duration) -> Result<(), ReaderError> {
+        let mut guard = self
+            .device
+            .lock()
+            .map_err(|_| ReaderError::Device("Failed to lock PN532 device".into()))?;
+
+        let start = Instant::now();
+        let mut status = [0u8; 1];
+        while start.elapsed() < timeout {
+            guard
+                .read_exact(&mut status)
+                .map_err(|e| ReaderError::Device(e.to_string()))?;
+            if status[0] == 0x01 {
+                let mut ack = [0u8; 6];
+                guard
+                    .read_exact(&mut ack)
+                    .map_err(|e| ReaderError::Device(e.to_string()))?;
+                if ack == ACK_FRAME {
+                    return Ok(());
+                } else {
+                    return Err(ReaderError::Protocol(format!(
+                        "Unexpected ACK frame: {:02x?}",
+                        ack
+                    )));
+                }
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        Err(ReaderError::Timeout)
+    }
+
+    fn read_response(&self, expected: u8, timeout: Duration) -> Result<Vec<u8>, ReaderError> {
+        let mut guard = self
+            .device
+            .lock()
+            .map_err(|_| ReaderError::Device("Failed to lock PN532 device".into()))?;
+
+        let start = Instant::now();
+        let mut status = [0u8; 1];
+        while start.elapsed() < timeout {
+            guard
+                .read_exact(&mut status)
+                .map_err(|e| ReaderError::Device(e.to_string()))?;
+            if status[0] != 0x01 {
+                thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+
+            let mut header = [0u8; 5];
+            guard
+                .read_exact(&mut header)
+                .map_err(|e| ReaderError::Device(e.to_string()))?;
+            if header[0] != 0x00 || header[1] != 0x00 || header[2] != 0xFF {
+                return Err(ReaderError::Protocol(format!(
+                    "Unexpected response header: {:02x?}",
+                    header
+                )));
+            }
+            let len = header[3] as usize;
+            let lcs = header[4];
+            if len.wrapping_add(lcs as usize) & 0xFF != 0 {
+                return Err(ReaderError::Protocol("Invalid length checksum".into()));
+            }
+
+            let mut payload = vec![0u8; len + 2];
+            guard
+                .read_exact(&mut payload)
+                .map_err(|e| ReaderError::Device(e.to_string()))?;
+
+            let tfi = payload[0];
+            if tfi != 0xD5 {
+                return Err(ReaderError::Protocol(format!(
+                    "Unexpected frame identifier: {:02x}",
+                    tfi
+                )));
+            }
+            if payload[1] != expected + 1 {
+                return Err(ReaderError::Protocol(format!(
+                    "Unexpected response code: {:02x}",
+                    payload[1]
+                )));
+            }
+
+            let data = &payload[2..len];
+            let dcs = payload[len];
+            let postamble = payload[len + 1];
+
+            let mut checksum: u8 = 0xD5;
+            checksum = checksum.wrapping_add(payload[1]);
+            for byte in data {
+                checksum = checksum.wrapping_add(*byte);
+            }
+            if dcs != (!checksum).wrapping_add(1) {
+                return Err(ReaderError::Protocol("Invalid data checksum".into()));
+            }
+            if postamble != 0x00 {
+                return Err(ReaderError::Protocol("Missing postamble".into()));
+            }
+
+            return Ok(data.to_vec());
+        }
+        Err(ReaderError::Timeout)
+    }
+
+    fn configure_sam(&self) -> Result<(), ReaderError> {
+        self.send_command(0x14, &[0x01, 0x14, 0x01])?;
+        self.read_ack(DEFAULT_TIMEOUT)?;
+        let _ = self.read_response(0x14, DEFAULT_TIMEOUT)?;
+        Ok(())
+    }
+
+    fn in_list_passive_target(&self, timeout: Duration) -> Result<Option<Vec<u8>>, ReaderError> {
+        self.send_command(0x4A, &[0x01, 0x00])?;
+        self.read_ack(DEFAULT_TIMEOUT)?;
+        let response = self.read_response(0x4A, timeout)?;
+        if response.is_empty() {
+            return Ok(None);
+        }
+        let tags_found = response[0];
+        if tags_found == 0 {
+            return Ok(None);
+        }
+        if response.len() < 6 {
+            return Err(ReaderError::Protocol("Incomplete InListPassiveTarget response".into()));
+        }
+        let uid_length = response[5] as usize;
+        if response.len() < 6 + uid_length {
+            return Err(ReaderError::Protocol("Invalid UID length in response".into()));
+        }
+        Ok(Some(response[6..6 + uid_length].to_vec()))
+    }
+}
+
+impl Reader for Pn532Reader {
+    fn init(&mut self) -> Result<(), ReaderError> {
+        if self.is_initialized {
+            return Ok(());
+        }
+        self.wakeup()?;
+        self.configure_sam()?;
+        self.is_initialized = true;
+        Ok(())
+    }
+
+    fn read_uid(&mut self, timeout: Duration) -> Result<Vec<u8>, ReaderError> {
+        self.init()?;
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            match self.in_list_passive_target(Duration::from_millis(500))? {
+                Some(uid) => return Ok(uid),
+                None => thread::sleep(Duration::from_millis(100)),
+            }
+        }
+        Err(ReaderError::Timeout)
     }
 
     fn get_reader_type(&self) -> ReaderType {
         ReaderType::NFC
     }
 }
+
+fn configure_slave_address(fd: RawFd, address: u16) -> Result<(), ReaderError> {
+    let result = unsafe { libc::ioctl(fd, I2C_SLAVE_IOCTL, address as c_ulong) };
+    if result < 0 {
+        return Err(ReaderError::Device(format!(
+            "Failed to set I2C slave address: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+

--- a/src-tauri/src/reader/rdm6300.rs
+++ b/src-tauri/src/reader/rdm6300.rs
@@ -1,16 +1,20 @@
-use reader::{Reader, ReaderType};
+use std::time::Duration;
 
-pub struct RDM6300 {}
+use super::{Reader, ReaderError, ReaderType};
 
-impl Reader for RDM6300 {
-    fn init(&mut self) -> Result<(), Box<dyn Error>> {
-        // Initialization logic for RDM6300
-        Ok(())
+pub struct Rdm6300;
+
+impl Reader for Rdm6300 {
+    fn init(&mut self) -> Result<(), ReaderError> {
+        Err(ReaderError::Initialization(
+            "RDM6300 reader is not implemented".into(),
+        ))
     }
 
-    fn read_uid(&mut self, timeout: i32) -> Result<Vec<u8>, Box<dyn Error>> {
-        // Logic to read UID from RDM6300
-        Ok(vec![0x00, 0x01, 0x02, 0x03]) // Example UID
+    fn read_uid(&mut self, _timeout: Duration) -> Result<Vec<u8>, ReaderError> {
+        Err(ReaderError::Device(
+            "RDM6300 reader is not available in this build".into(),
+        ))
     }
 
     fn get_reader_type(&self) -> ReaderType {

--- a/src-tauri/src/reader/reader.rs
+++ b/src-tauri/src/reader/reader.rs
@@ -1,14 +1,40 @@
-pub trait Reader {
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::time::Duration;
+
+#[derive(Debug)]
+pub enum ReaderError {
+    Initialization(String),
+    Timeout,
+    Device(String),
+    Protocol(String),
+}
+
+impl Display for ReaderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReaderError::Initialization(msg) => write!(f, "Reader initialization failed: {}", msg),
+            ReaderError::Timeout => write!(f, "Timed out while waiting for a card"),
+            ReaderError::Device(msg) => write!(f, "Reader device error: {}", msg),
+            ReaderError::Protocol(msg) => write!(f, "Reader protocol error: {}", msg),
+        }
+    }
+}
+
+impl Error for ReaderError {}
+
+pub trait Reader: Send {
     /// Initializes the reader device.
-    fn init(&mut self) -> Result<(), Box<dyn Error>>;
+    fn init(&mut self) -> Result<(), ReaderError>;
 
     /// Returns the unique identifier (UID) of the current tag.
-    fn read_uid(&mut self, timeout: i32) -> Result<Vec<u8>, Box<dyn Error>>;
+    fn read_uid(&mut self, timeout: Duration) -> Result<Vec<u8>, ReaderError>;
 
     /// Gets the type of the reader.
     fn get_reader_type(&self) -> ReaderType;
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum ReaderType {
     NFC,
     RFID,


### PR DESCRIPTION
- add a reusable reader abstraction and implement a PN532 I2C backend
- expose PN532 scans to the existing card workflow and allow fallback test cards in the UI
- add project ignores for build artefacts and ensure placeholder RDM6300 implementation reports unsupported